### PR TITLE
update readme to add node 18.2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The front-end builder must match the following standard
 - icejs and umijs, only supports React and has too many runtime.
 - turbopack, only supports Next.js.
 
+## Requirement
+```
+node version 18.2 or greater
+```
+
 ## Test Code Base
 
 - 420 React components


### PR DESCRIPTION
`closeAllConnections` was introduces in node 18.2.0 -
Running on a lower version will result in error 
```
    /**
         * Closes all connections connected to this server.
         * @since v18.2.0
         */
         closeAllConnections(): void;
```

Thank you 